### PR TITLE
PR Label Added | Adds Label Automatically on Successfully Merging of PR

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,15 @@
+name: Add label to Merged PR
+
+on:
+  pull_request_target:
+    types: [closed]
+
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labeling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 'GSSOC21'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,3 +15,7 @@ jobs:
         uses: andymckay/labeler@master
         with:
           add-labels: 'GSSOC21'
+          
+          
+          
+        

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,15 +1,17 @@
 name: Add label to Merged PR
 
+# The events for whcih this workflow wii be triggered
 on:
   pull_request_target:
     types: [closed]
 
-
+# The machine will run each job when workflow will be triggered
 jobs:
   automate-issues-labels:
     runs-on: ubuntu-latest
+    # These tasks will be run in each job
     steps:
       - name: initial labeling
         uses: andymckay/labeler@master
         with:
-          add-labels: 'GSSOC21'
+          add-labels: 'gssoc21'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,4 +14,4 @@ jobs:
       - name: initial labeling
         uses: andymckay/labeler@master
         with:
-          add-labels: 'gssoc21'
+          add-labels: 'GSSOC21'


### PR DESCRIPTION
## Fixes #2022 

- pr-labeler by using GitHub Action


#### Adding the .yml file

I have added the pr-labeler with the help of taking labeler and pr closed action. The job of this Action will be to add the GSSOC21 label on Merged PR.

## Trial Checking

I have Tried the Code on my Repository, GitHub Bot Adds the GSSOC21 Label Automatically after the PR is merged Successfully. Here is the Screenshot that Shows How the Workflow works!

![Capture](https://user-images.githubusercontent.com/73196470/119857293-0f8af600-bf31-11eb-9253-173567e65abf.JPG)

# -------- Screenshot  ---------

![sadf](https://user-images.githubusercontent.com/73196470/119939173-0f2f4100-bfab-11eb-8078-107f2b9905cf.JPG)
