### PR TITLE
Automated Message added on pr merge

### DIFF
--- a/.github/workflows/Auto_message_on_pr_merge.yml
+++ b/.github/workflows/Auto_message_on_pr_merge.yml
@@ -16,3 +16,8 @@ jobs:
         respondableId: ${{ github.event.pull_request.node_id }}
         response: "Congratulations 🎉🎊, Your PR has been Merged and Thank you @${{ github.event.pull_request.user.login }} for taking out your valuable time in order to contribute to AlgoTree. Looking forward for more such amazing contributions :)"
         author: ${{ github.event.pull_request.user.login }}
+        
+        
+        
+        
+        

--- a/.github/workflows/Auto_message_on_pr_merge.yml
+++ b/.github/workflows/Auto_message_on_pr_merge.yml
@@ -1,0 +1,18 @@
+name: congratulations  Message on PR merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: derekprior/add-autoresponse@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        respondableId: ${{ github.event.pull_request.node_id }}
+        response: "Congratulations 🎉🎊, Your PR has been Merged and Thank you @${{ github.event.pull_request.user.login }} for taking out your valuable time in order to contribute to AlgoTree. Looking forward for more such amazing contributions :)"
+        author: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION

## Fixes #2024  

- Automated Message on PR Merge


#### Adding the .yml file

I have added .github/workflows/Auto_message_on_pr_merge.yml with the help of pr closed action. The job of this Action will be to echo the message on Merged PR.

## Trial Checking

I have Tried the Code on my Repository, GitHub Bot Gives the Below Message Automatically after the PR is merged Successfully. Here is the Screenshot that Shows How the Workflow works!

# -------- Screenshot  ---------

![cong message](https://user-images.githubusercontent.com/73196470/119958599-d13d1780-bfc0-11eb-906e-9ba9cdb8e0a9.JPG)
