### PR TITLE
Adding Auto Message about Code Guidelines on creating issue

### DIFF
--- a/.github/workflows/Auto_message_on_creatingissues.yml
+++ b/.github/workflows/Auto_message_on_creatingissues.yml
@@ -16,3 +16,7 @@ jobs:
         body: |
             Hi 😄, @${{ github.actor }} Thanks for creating  issue at AlgoTree, do read and follow the [Code of Conduct](https://github.com/Algo-Phantoms/Algo-Tree/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/Algo-Phantoms/Algo-Tree/blob/main/GUIDLINES.md) while contributing. Refer to PR's which has been merged earlier in AlgoTree [Click Here](https://github.com/Algo-Phantoms/Algo-Tree/pulse#merged-pull-requests) Like, How many File they have changed?, Which type of files need to be change? and many more.
     
+    
+    
+    
+    

--- a/.github/workflows/Auto_message_on_creatingissues.yml
+++ b/.github/workflows/Auto_message_on_creatingissues.yml
@@ -1,0 +1,18 @@
+name: Auto message on Creating Issue.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create comment for issue
+      if: github.event_name =='issues' 
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{tojson(github.event.issue.number)}}
+        body: |
+            Hi 😄, @${{ github.actor }} Thanks for creating  issue at AlgoTree, do read and follow the [Code of Conduct](https://github.com/Algo-Phantoms/Algo-Tree/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/Algo-Phantoms/Algo-Tree/blob/main/GUIDLINES.md) while contributing. Refer to PR's which has been merged earlier in AlgoTree [Click Here](https://github.com/Algo-Phantoms/Algo-Tree/pulse#merged-pull-requests) Like, How many File they have changed?, Which type of files need to be change? and many more.
+    


### PR DESCRIPTION
## Fixes #2020 
## Adding Auto Message about Code Guidelines on creating issue [ Bot ]
This Bot will Give a Message for all created issues where Contributors will be provided the link for code of conduct and contribution guidelines as well as liked to merged pr for their reference.

As a result, Project will get quality of PR and Hence will improve everyone's Productivity (for Mentors/ Reviewers and Participants as well)

## Screenshots of Testing & Checking
![nn -msg-on-new issue](https://user-images.githubusercontent.com/73196470/119980729-52ed6f00-bfda-11eb-91af-7724b7167145.JPG)

